### PR TITLE
Add styles for the optional year and month dropdowns

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -66,6 +66,11 @@
 .ui-datepicker .ui-datepicker-prev span {
 	background-position: -96px 0;
 }
+.ui-datepicker select.ui-datepicker-year,
+.ui-datepicker select.ui-datepicker-month {
+	border: none;
+	margin-left: 6px;
+}
 .ui-datepicker th {
 	padding: 0.75em 0;
 	color: #fff;

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -77,6 +77,12 @@
 		background-position: -96px 0;
 	}
 
+	select.ui-datepicker-year,
+	select.ui-datepicker-month {
+		border: none;
+		margin-left: 6px;
+	}
+
 	th {
 		padding: 0.75em 0;
 		color: #fff;

--- a/sass/datepicker.scss
+++ b/sass/datepicker.scss
@@ -77,6 +77,12 @@
 		background-position: -96px 0;
 	}
 
+	select.ui-datepicker-year,
+	select.ui-datepicker-month {
+		border: none;
+		margin-left: 6px;
+	}
+
 	th {
 		padding: 0.75em 0;
 		color: #fff;


### PR DESCRIPTION
The [optional month and year menus](http://jqueryui.com/datepicker/#dropdown-month-year) are helpful when dates the user often picks can potentially be several months and/or years away from the current date.

They haven't been styled in the skin yet, though, so they have an ugly border and are squished together. This removes the border and adds some space between them.
